### PR TITLE
Update Node.js workflow to remove Yarn cache setting

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '22' # Updated to Node 22
-          cache: 'yarn'
 
       # Step 3: Enable and prepare Corepack
       - name: Enable Corepack


### PR DESCRIPTION
Removed the 'cache: yarn' configuration in the GitHub Actions workflow for Node.js. This simplifies caching logic, aligning with updated Node 22 configurations and Corepack usage.