### PR TITLE
Remove redundant Yarn version verification step

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,8 +25,6 @@ jobs:
         run: |
           corepack enable
           corepack prepare yarn@stable --activate
-      - name: Verify Yarn Version
-        run: yarn --version
 
       # Step 4: Install dependencies
       - name: Install Dependencies


### PR DESCRIPTION
The step to verify Yarn version was unnecessary, as corepack ensures the correct version. This simplifies the workflow and removes redundant operations, improving efficiency.