### PR TITLE
Add ngx-services build step and adjust style size limit

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -79,7 +79,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "4kB",
-                  "maximumError": "12kB"
+                  "maximumError": "15kB"
                 }
               ],
               "outputHashing": "all",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "i18n": "ng extract-i18n gilles.dev --format=xlf --out-file=src/locale/messages.xlf",
     "eslint": "eslint src && eslint projects",
     "format": "npx prettier -w ./src ./projects",
-    "prod": "ng build --configuration production --base-href \"/\"",
+    "prod": "ng build ngx-services && ng build --configuration production --base-href \"/\"",
     "deploy": "ngh --dir=dist/gilles.dev/browser",
     "ng": "ng",
     "start": "ng serve gilles.dev --hmr=false",


### PR DESCRIPTION
Updated the production build script to include `ngx-services` to prepare its build before the main application. Increased the style size error threshold from 12kB to 15kB to allow for more flexibility in styling.