### PR TITLE
Add shared WordPress types and update service imports

### DIFF
--- a/projects/ngx-services/src/lib/wordpress.service.ts
+++ b/projects/ngx-services/src/lib/wordpress.service.ts
@@ -1,11 +1,11 @@
 import { inject, Injectable } from '@angular/core';
 import { HttpService } from './http.service';
 import { catchError, first, Observable, shareReplay } from 'rxjs';
-import { WordpressPublicRequestParams, WordpressSelfRequestParams } from 'shared-wordpress';
 import { HttpErrorResponse } from '@angular/common/http';
 import { WordpressSelfSinglePostMedia } from './wordpress.self.media.interface';
 import { WordpressSelfSinglePost } from './wordpress.self.interface';
 import { WordpressPublicPosts, WordpressPublicSinglePost } from './wordpress.interface';
+import { WordpressPublicRequestParams, WordpressSelfRequestParams } from './wordpress.shared';
 
 @Injectable()
 export class WordpressService {

--- a/projects/ngx-services/src/lib/wordpress.shared.ts
+++ b/projects/ngx-services/src/lib/wordpress.shared.ts
@@ -1,0 +1,24 @@
+export interface WordpressResponse<T> {
+  data: T;
+  error?: string | null;
+}
+
+export enum WordpressParamsOrder {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+interface WordpressPublicParams {
+  limit: number;
+  category: string;
+  order: WordpressParamsOrder;
+}
+
+interface WordpressSelfParams {
+  limit: number;
+  categories: string;
+  order: WordpressParamsOrder;
+}
+
+export type WordpressPublicRequestParams = Partial<WordpressPublicParams>;
+export type WordpressSelfRequestParams = Partial<WordpressSelfParams>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,26 +8,8 @@
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "paths": {
-      "js-enum": [
-        "./dist/js-enum"
-      ],
-      "js-helper": [
-        "./dist/js-helper"
-      ],
-      "js-interface": [
-        "./dist/js-interface"
-      ],
-      "ngx-components": [
-        "./dist/ngx-components"
-      ],
       "ngx-services": [
         "./dist/ngx-services"
-      ],
-      "shared-strapi": [
-        "./dist/shared-strapi"
-      ],
-      "shared-wordpress": [
-        "./dist/shared-wordpress"
       ]
     },
     "noImplicitReturns": true,


### PR DESCRIPTION
Introduced reusable type definitions for WordPress parameters and responses in a new shared file. Updated the `WordpressService` to use these common types and removed unused TypeScript path mappings from the configuration.